### PR TITLE
Added EvalCommand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,17 +47,17 @@
             <version>4.2.0_223</version>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>com.github.XillaTech</groupId>-->
-<!--            <artifactId>Xilla-Core</artifactId>-->
-<!--            <version>429119c53a</version>-->
-<!--        </dependency>-->
-
         <dependency>
+            <groupId>com.github.XillaTech</groupId>
+            <artifactId>Xilla-Core</artifactId>
+            <version>429119c53a</version>
+       </dependency>
+
+<!---        <dependency>
             <groupId>net.xilla</groupId>
             <artifactId>Core</artifactId>
             <version>1.0.1</version>
-        </dependency>
+    </dependency> -->
 
         <!-- https://mvnrepository.com/artifact/com.vdurmont/emoji-java -->
         <dependency>
@@ -87,6 +87,12 @@
             <version>1.16-R0.3</version>
             <type>javadoc</type>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>3.0.7</version>
         </dependency>
 
     </dependencies>
@@ -142,7 +148,7 @@
                 </executions>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <minimizeJar>true</minimizeJar>
+                    <minimizeJar>false</minimizeJar>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/net/xilla/discordcore/command/cmd/EvalCommand.java
+++ b/src/main/java/net/xilla/discordcore/command/cmd/EvalCommand.java
@@ -1,0 +1,68 @@
+package net.xilla.discordcore.command.cmd;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.xilla.discordcore.CoreObject;
+import net.xilla.discordcore.command.CommandBuilder;
+import net.xilla.discordcore.core.command.response.CoreCommandResponse;
+import net.xilla.discordcore.core.permission.PermissionAPI;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class EvalCommand extends CoreObject {
+
+    private static final ScriptEngine SCRIPT_ENGINE = new ScriptEngineManager().getEngineByName("groovy");
+    private static final List<String> DEFAULT_IMPORTS = Arrays.asList("net.dv8tion.jda.api.entities.impl", "net.dv8tion.jda.api.managers", "net.dv8tion.jda.api.entities", "net.dv8tion.jda.api",
+            "java.io", "java.math", "java.util", "java.util.concurrent", "java.time", "java.util.stream", "com.vdurmont.emoji", "net.xilla.discordcore", "net.xilla.discordcore.core"
+    );
+
+    public EvalCommand() {
+        CommandBuilder commandBuilder = new CommandBuilder("Core", "eval", false);
+        commandBuilder.setDescription("Executes (potentially unsafe) Java and Javascript code. **Only use if you know what you're doing**");
+        commandBuilder.setCommandExecutor((data) -> {
+            MessageReceivedEvent event = (MessageReceivedEvent) data.get();
+
+            if (!PermissionAPI.hasPermission(event.getMember(), "core.eval")) return new CoreCommandResponse(data).setDescription("Improper Permissions. Missing `core.eval`");
+
+            Color color = Color.GREEN;
+            String status = "Success";
+            Object out;
+            SCRIPT_ENGINE.put("event", event);
+            SCRIPT_ENGINE.put("message", event.getMessage());
+            SCRIPT_ENGINE.put("channel", event.getChannel());
+            SCRIPT_ENGINE.put("args", data.getArgs());
+            SCRIPT_ENGINE.put("api", event.getJDA());
+            SCRIPT_ENGINE.put("jda", event.getJDA());
+            SCRIPT_ENGINE.put("guild", event.getGuild());
+            SCRIPT_ENGINE.put("member", event.getMember());
+
+            StringBuilder imports = new StringBuilder();
+            DEFAULT_IMPORTS.forEach(imp -> imports.append("import ").append(imp).append(".*; "));
+            String code = String.join(" ", data.getArgs());
+            long start = System.currentTimeMillis();
+            try {
+                out = SCRIPT_ENGINE.eval(imports + code);
+            } catch (Exception e) {
+                out = e.getMessage();
+                color = Color.RED;
+                status = "Failed";
+            }
+
+            EmbedBuilder embedBuilder = getEmbed(event)
+                    .setTitle("Eval")
+                    .setColor(color)
+                    .addField("Status:", status, true)
+                    .addField("Duration:", (System.currentTimeMillis() - start) + "ms", true)
+                    .addField("Code:", "```java\n" + code + "\n```", false)
+                    .addField("Result:", out == null ? "" : out.toString(), false);
+            return new CoreCommandResponse(data).setEmbed(embedBuilder.build());
+        });
+        commandBuilder.build();
+    }
+
+}

--- a/src/main/java/net/xilla/discordcore/core/Platform.java
+++ b/src/main/java/net/xilla/discordcore/core/Platform.java
@@ -56,6 +56,7 @@ public class Platform extends CoreObject {
         new SettingsCommand();
         new EmbedCommand();
         new CoreCommands();
+        new EvalCommand();
 
         DiscordCore.getInstance().getCommandManager().setPermissionError((args, data) -> {
             EmbedBuilder builder = new EmbedBuilder();


### PR DESCRIPTION
Allows execution of (potentially unsafe) Java and Javascript code using the Groovy Script Engine. 

Command is locked to users with permission `core.eval`

Returns via Embed